### PR TITLE
sublime text2 support and fix filename input

### DIFF
--- a/snippet_maker.py
+++ b/snippet_maker.py
@@ -23,7 +23,7 @@ class MakeSnippetCommand(sublime_plugin.TextCommand):
 
     def set_trigger(self, trigger):
         self.trigger = trigger
-        self.view.window().show_input_panel('Description', 'Default', self.set_description, None, None)
+        self.view.window().show_input_panel('Description', '', self.set_description, None, None)
 
     def set_description(self, description):
         self.description = description


### PR DESCRIPTION
On Sublime Text2, old code didn't work. So, support sublimeText2 style file.write() function to fix it.

Filename input panel's default value is now just "Default", and add  '.sublime-snippet'  after reading the input. With this change, it will be easier to edit the filename.
