### PR TITLE
Add ability to delete snippets using the Command Palette

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -6,5 +6,9 @@
     {
         "caption": "SnippetMaker: Edit Snippet",
         "command": "edit_snippet"
+    },
+    {
+        "caption": "SnippetMaker: Delete Snippet",
+        "command": "delete_snippet"
     }
 ]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ $ git clone https://github.com/jugyo/SublimeSnippetMaker.git SnippetMaker
 
 * Select text for snippet then execute the `Make Snippet` command in the Command Palette.
 * And you can edit your snippets by using `Edit Snippet` command.
+* If you need to delete a snippet, use the `Delete Snippet` command.
 
 ### Edit by @fabiantheblind
 
 Added additional input for description.
+
+### Edit by @jakebathman
+
+Added ability to delete snippets through the Command Palette

--- a/snippet_maker.py
+++ b/snippet_maker.py
@@ -77,3 +77,28 @@ class EditSnippetCommand(sublime_plugin.WindowCommand):
                 self.window.open_file(snippets[index][1], sublime.TRANSIENT)
 
         self.window.show_quick_panel([_[0] for _ in snippets], on_done, sublime.MONOSPACE_FONT, -1, on_highlight)
+
+class DeleteSnippetCommand(sublime_plugin.WindowCommand):
+    def run(self):
+        snippets = [
+            [os.path.basename(filepath), filepath]
+                for filepath
+                    in iglob(os.path.join(sublime.packages_path(), 'User', '*.sublime-snippet'))]
+
+        def on_done(index):
+          global snippetFile
+          snippetFile = snippets[index]
+          items = [
+            ["DELETE FILE?!","Are you sure you want to delete this snippet?"],
+            ["No","Do not delete"],
+            ["Yes","Delete this snippet file immediately"]
+          ]
+          self.window.show_quick_panel(items, delete_file)
+
+        def delete_file(index):
+          global snippetFile
+          if index == 2:
+            os.remove(snippetFile[1])
+            sublime.message_dialog("Snippet successfully deleted: " + snippetFile[0])
+
+        self.window.show_quick_panel([_[0] for _ in snippets], on_done, sublime.MONOSPACE_FONT, -1)


### PR DESCRIPTION
After creating issue #11, I decided to add the ability myself.

This revision allows a user to delete a selected snippet using the command `Delete Snippet`. It will bring up a list of snippets to select, followed by a final Yes/No prompt before deleting the snippet file.

Tested on ST3 build 3083, Windows 7 x64 
