### PR TITLE
Adding preference "always_escape_dollar_sign"

### DIFF
--- a/SnippetMaker.py
+++ b/SnippetMaker.py
@@ -32,9 +32,16 @@ def get_snippets():
 
 class MakeSnippetCommand(sublime_plugin.TextCommand):
     def run(self, edit):
+        settings = sublime.load_settings('SnippetMaker.sublime-settings')
+        should_escape_dollar_sign = settings.get('always_escape_dollar_sign', True)
+
         self.snippet_text = "\n".join(
-            [self.view.substr(i).replace('$', '\\$') for i in self.view.sel()]
+            [self.view.substr(i) for i in self.view.sel()]
         )
+
+        if should_escape_dollar_sign:
+            self.snippet_text = self.snippet_text.replace('$', '\\$')
+
         sublime.active_window().show_input_panel(
             'Trigger',
             '',

--- a/SnippetMaker.sublime-settings
+++ b/SnippetMaker.sublime-settings
@@ -2,6 +2,8 @@
 	// Specify a folder for SnippetMaker to manage.
 	// It will be stored in Packages/User/ and new snippets will be stored here.
 	// The Edit and Delete commands will also look here for snippets to edit.
+	"snippet_location": "Snippets",
 
-    "snippet_location": "Snippets"
+	// If should always escape "$" to "\$" when creating a new snippet
+	"always_escape_dollar_sign": true
 }


### PR DESCRIPTION
Fixes #20 

Added
```json
"always_escape_dollar_sign": true
```
to `SnippetMaker.sublime-settings`.

Now the user has the option to choose not to escape the dollar signs on the selected text when creating a new snippet.